### PR TITLE
For some reason, savedArray – supposed to store NSDictionnary values – c...

### DIFF
--- a/Preference Panes/OSIPACSOnDemandPreferencePane/OSIPACSOnDemandPreferencePane.m
+++ b/Preference Panes/OSIPACSOnDemandPreferencePane/OSIPACSOnDemandPreferencePane.m
@@ -118,6 +118,9 @@ static NSMatrix *gDateMatrix = nil;
 	
 	for( NSUInteger i = 0; i < [savedArray count]; i++)
 	{
+        if (![[savedArray objectAtIndex:i] isKindOfClass:[NSDictionary class]])
+            continue;
+
 		NSDictionary *server = [self findCorrespondingServer: [savedArray objectAtIndex:i] inServers: serversArray];
 		
 		//if( server && ([[server valueForKey:@"QR"] boolValue] == YES || [server valueForKey:@"QR"] == nil ))


### PR DESCRIPTION
...ontains something else (e.g. NSString @"MINIPACS").
It prevents PACS On-Demand even to be selected in the Preferences.
