### PR TITLE
Don't include unnecessary OsiriX/DCMObject.h

### DIFF
--- a/XMLController.h
+++ b/XMLController.h
@@ -16,9 +16,9 @@
 
 #import <Cocoa/Cocoa.h>
 #import "OSIWindowController.h"
-#import "OsiriX/DCMObject.h"
 
 @class ViewerController;
+@class DCMObject;
 
 /** \brief Window Controller for XML parsing */
 


### PR DESCRIPTION
Don't include unnecessary OsiriX/DCMObject.h that points to a DCMFramework header in an OsiriXAPI header
