### PR TITLE
Fixed multiframe files not splitting properly

### DIFF
--- a/DicomFileDCMTKCategory.mm
+++ b/DicomFileDCMTKCategory.mm
@@ -867,8 +867,9 @@ extern NSRecursiveLock *PapyrusLock;
                             while (count < 3 && eitem->findAndGetFloat64(DCM_ImagePositionPatient, originMultiFrame[count], count, OFFalse).good())
                                 count++;
                             
-                            if( count != 3)
-                                succeed = NO;
+                            if( count == 3)
+                                succeed = YES;
+                            else succeed = NO;
                         }
                         else succeed = NO;
                         
@@ -878,8 +879,9 @@ extern NSRecursiveLock *PapyrusLock;
                             while (count < 6 && eitem->findAndGetFloat64(DCM_ImageOrientationPatient, orientationMultiFrame[count], count, OFFalse).good())
                                 count++;
                             
-                            if( count != 6 && count != 0)
-                                succeed = NO;
+                            if( count == 6)
+                                succeed = YES;
+                            else succeed = NO;
                         }
                         else succeed = NO;
 					}


### PR DESCRIPTION
Multiframe MR files were not being split properly in newer versions.

Control structures in DicomFileDCMTKCategory for multiframe files were setting the 'success' flag to NO, and subsequent conditionals had no way to change it to YES. 

I think this regression was introduced in @a6a9bb65ff0b (MD-438).

I believe this fixes #37 , and also fixes #30, my previously reported multi-echo file splitting problem.

I have only tested this change with MR files. Please evaluate if this change is acceptable (and has no unforeseen consequences).

Thanks!
