### PR TITLE
Compute sliceIntervals in PluginSDK

### DIFF
--- a/OSIVolumeWindow.m
+++ b/OSIVolumeWindow.m
@@ -144,6 +144,7 @@ NSString* const OSIVolumeWindowDidChangeDataNotification = @"OSIVolumeWindowDidC
     assert(pixList);
     assert(volumeData);
     
+    [_viewerController computeInterval];
     floatVolumeData = [[[OSIFloatVolumeData alloc] initWithWithPixList:pixList volume:volumeData] autorelease];
     
     [_generatedFloatVolumeDatas setObject:floatVolumeData forKey:dimensionAndIndexKey];


### PR DESCRIPTION
Make the plugin SDK ask the ViewerController to compute slice intervals before building the FloatVolumeData
