### PR TITLE
Plugin loading with --LoadPlugin

### DIFF
--- a/OsiriXClasses/GUI/PluginManager.m
+++ b/OsiriXClasses/GUI/PluginManager.m
@@ -743,6 +743,7 @@ BOOL gPluginsAlertAlreadyDisplayed = NO;
         }
         
         NSMutableArray* pathsOfPluginsToLoad = [NSMutableArray array];
+        NSMutableArray* dontLoadOtherWithTheseNames = [NSMutableArray array];
         
         for (id path in paths)
             @try {
@@ -755,7 +756,15 @@ BOOL gPluginsAlertAlreadyDisplayed = NO;
 
                 NSEnumerator* e = nil;
                 if ([path isKindOfClass:[NSString class]])
-                    e = [[[NSFileManager defaultManager] directoryContentsAtPath:path] objectEnumerator];
+                {
+                    NSArray* pluginsInDir = [[NSFileManager defaultManager] directoryContentsAtPath:path];
+                    e = [[pluginsInDir filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSString* plugin, NSDictionary* bindings) {
+                        BOOL listed = [dontLoadOtherWithTheseNames containsObject:plugin];
+                        if (listed)
+                            NSLog(@"Won't load %@ from %@ in favor of %@", plugin, path, [[pathsOfPluginsToLoad filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"lastPathComponent = %@", plugin]] lastObject]);
+                        return !listed;
+                    }]] objectEnumerator];
+                }
                 else if (path == [NSNull null])
                 {
                     path = @"/";
@@ -763,7 +772,9 @@ BOOL gPluginsAlertAlreadyDisplayed = NO;
                     NSArray* args = [[NSProcessInfo processInfo] arguments];
                     for (NSInteger i = 0; i < [args count]; ++i)
                         if ([[args objectAtIndex:i] isEqualToString:@"--LoadPlugin"] && [args count] > i+1) {
-                            [cl addObject:[args objectAtIndex:++i]];
+                            NSString* pluginpath = [args objectAtIndex:++i];
+                            [cl addObject:pluginpath];
+                            [dontLoadOtherWithTheseNames addObject:pluginpath.lastPathComponent];
                         }
                     e = [cl objectEnumerator];
                 }


### PR DESCRIPTION
This change only avoids that OsiriX loads a plugin the "old" way when that plugin is being loaded through --LoadPlugin, so we can easily test a new version without having to uninstall the old version from the Library dirs. Based strictly on lastPathComponent.
