### PR TITLE
updating to nifticlib 2.0.0 and fixing tLayer ROI image hitTest

### DIFF
--- a/NIfTI_Library/nifti1.h
+++ b/NIfTI_Library/nifti1.h
@@ -1,5 +1,12 @@
 /** \file nifti1.h
     \brief Official definition of the nifti1 header.  Written by Bob Cox, SSCC, NIMH.
+
+    HISTORY:
+
+        29 Nov 2007 [rickr]
+           - added DT_RGBA32 and NIFTI_TYPE_RGBA32
+           - added NIFTI_INTENT codes:
+                TIME_SERIES, NODE_INDEX, RGB_VECTOR, RGBA_VECTOR, SHAPE
  */
 
 #ifndef _NIFTI_HEADER_
@@ -286,7 +293,7 @@ typedef struct nifti1_extender nifti1_extender ;
 struct nifti1_extension {
    int    esize ; /*!< size of extension, in bytes (must be multiple of 16) */
    int    ecode ; /*!< extension code, one of the NIFTI_ECODE_ values       */
-   char * edata ; /*!< raw data, with no byte swapping                      */
+   char * edata ; /*!< raw data, with no byte swapping (length is esize-8)  */
 } ;
 typedef struct nifti1_extension nifti1_extension ;
 
@@ -504,6 +511,7 @@ typedef struct nifti1_extension nifti1_extension ;
 #define DT_FLOAT128             1536     /* long double (128 bits)       */
 #define DT_COMPLEX128           1792     /* double pair (128 bits)       */
 #define DT_COMPLEX256           2048     /* long double pair (256 bits)  */
+#define DT_RGBA32               2304     /* 4 byte RGBA (32 bits/voxel)  */
 /* @} */
 
 
@@ -543,6 +551,8 @@ typedef struct nifti1_extension nifti1_extension ;
 #define NIFTI_TYPE_COMPLEX128   1792
                                        /*! 256 bit complex = 2 128 bit floats */
 #define NIFTI_TYPE_COMPLEX256   2048
+                                       /*! 4 8 bit bytes. */
+#define NIFTI_TYPE_RGBA32       2304
 /* @} */
 
                      /*-------- sample typedefs for complicated types ---*/
@@ -904,6 +914,45 @@ typedef struct { unsigned char r,g,b; } rgb_byte ;
      the name of the parameter may be stored in intent_name.     */
 
 #define NIFTI_INTENT_DIMLESS    1011
+
+ /*---------- these values apply to GIFTI datasets ----------*/
+
+ /*! To signify that the value at each location is from a time series. */
+
+#define NIFTI_INTENT_TIME_SERIES  2001
+
+ /*! To signify that the value at each location is a node index, from
+     a complete surface dataset.                                       */
+
+#define NIFTI_INTENT_NODE_INDEX   2002
+
+ /*! To signify that the vector value at each location is an RGB triplet,
+     of whatever type.
+       - dataset must have a 5th dimension
+       - dim[0] = 5
+       - dim[1] = number of nodes
+       - dim[2] = dim[3] = dim[4] = 1
+       - dim[5] = 3
+    */
+
+#define NIFTI_INTENT_RGB_VECTOR   2003
+
+ /*! To signify that the vector value at each location is a 4 valued RGBA
+     vector, of whatever type.
+       - dataset must have a 5th dimension
+       - dim[0] = 5
+       - dim[1] = number of nodes
+       - dim[2] = dim[3] = dim[4] = 1
+       - dim[5] = 4
+    */
+
+#define NIFTI_INTENT_RGBA_VECTOR  2004
+
+ /*! To signify that the value at each location is a shape value, such
+     as the curvature.  */
+
+#define NIFTI_INTENT_SHAPE        2005
+
 /* @} */
 
 /*---------------------------------------------------------------------------*/

--- a/NIfTI_Library/znzlib.c
+++ b/NIfTI_Library/znzlib.c
@@ -124,26 +124,74 @@ int Xznzclose(znzFile * file)
 }
 
 
+/* we already assume ints are 4 bytes */
+#undef ZNZ_MAX_BLOCK_SIZE
+#define ZNZ_MAX_BLOCK_SIZE (1<<30)
+
 size_t znzread(void* buf, size_t size, size_t nmemb, znzFile file)
 {
+  size_t     remain = size*nmemb;
+  char     * cbuf = (char *)buf;
+  unsigned   n2read;
+  int        nread;
+
   if (file==NULL) { return 0; }
 #ifdef HAVE_ZLIB
-  if (file->zfptr!=NULL) 
-    return (size_t) (gzread(file->zfptr,buf,((int) size)*((int) nmemb)) / size);
+  if (file->zfptr!=NULL) {
+    /* gzread/write take unsigned int length, so maybe read in int pieces
+       (noted by M Hanke, example given by M Adler)   6 July 2010 [rickr] */
+    while( remain > 0 ) {
+       n2read = (remain < ZNZ_MAX_BLOCK_SIZE) ? remain : ZNZ_MAX_BLOCK_SIZE;
+       nread = gzread(file->zfptr, (void *)cbuf, n2read);
+       if( nread < 0 ) return nread; /* returns -1 on error */
+
+       remain -= nread;
+       cbuf += nread;
+
+       /* require reading n2read bytes, so we don't get stuck */
+       if( nread < (int)n2read ) break;  /* return will be short */
+    }
+
+    /* warn of a short read that will seem complete */
+    if( remain > 0 && remain < size )
+       fprintf(stderr,"** znzread: read short by %u bytes\n",(unsigned)remain);
+
+    return nmemb - remain/size;   /* return number of members processed */
+  }
 #endif
   return fread(buf,size,nmemb,file->nzfptr);
 }
 
 size_t znzwrite(const void* buf, size_t size, size_t nmemb, znzFile file)
 {
+  size_t     remain = size*nmemb;
+  char     * cbuf = (char *)buf;
+  unsigned   n2write;
+  int        nwritten;
+
   if (file==NULL) { return 0; }
 #ifdef HAVE_ZLIB
-  if (file->zfptr!=NULL)
-      {
-      /*  NOTE:  We must typecast const away from the buffer because
-          gzwrite does not have complete const specification */
-    return (size_t) ( gzwrite(file->zfptr,(void *)buf,size*nmemb) / size );
-      }
+  if (file->zfptr!=NULL) {
+    while( remain > 0 ) {
+       n2write = (remain < ZNZ_MAX_BLOCK_SIZE) ? remain : ZNZ_MAX_BLOCK_SIZE;
+       nwritten = gzwrite(file->zfptr, (void *)cbuf, n2write);
+
+       /* gzread returns 0 on error, but in case that ever changes... */
+       if( nwritten < 0 ) return nwritten;
+
+       remain -= nwritten;
+       cbuf += nwritten;
+
+       /* require writing n2write bytes, so we don't get stuck */
+       if( nwritten < (int)n2write ) break;
+    }
+
+    /* warn of a short write that will seem complete */
+    if( remain > 0 && remain < size )
+      fprintf(stderr,"** znzwrite: write short by %u bytes\n",(unsigned)remain);
+
+    return nmemb - remain/size;   /* return number of members processed */
+  }
 #endif
   return fwrite(buf,size,nmemb,file->nzfptr);
 }
@@ -167,7 +215,7 @@ int znzrewind(znzFile stream)
      if (stream->zfptr!=NULL) return gzrewind(stream->zfptr);
   */
 
-  if (stream->zfptr!=NULL) return (int)gzseek(stream->zfptr, nil, SEEK_SET);
+  if (stream->zfptr!=NULL) return (int)gzseek(stream->zfptr, 0L, SEEK_SET);
 #endif
   rewind(stream->nzfptr);
   return 0;
@@ -245,6 +293,7 @@ int znzgetc(znzFile file)
 int znzprintf(znzFile stream, const char *format, ...)
 {
   int retval=0;
+  char *tmpstr;
   va_list va;
   if (stream==NULL) { return 0; }
   va_start(va, format);

--- a/NIfTI_Library/znzlib.h
+++ b/NIfTI_Library/znzlib.h
@@ -47,10 +47,20 @@ extern "C" {
 #include <string.h>
 #include <stdarg.h>
 
-//#include "config.h"
+/* include optional check for HAVE_FDOPEN here, from deleted config.h:
 
-#ifdef HAVE_ZLIB 
+   uncomment the following line if fdopen() exists for your compiler and
+   compiler options
+*/
+/* #define HAVE_FDOPEN */
+
+
+#ifdef HAVE_ZLIB
+#if defined(ITKZLIB)
+#include "itk_zlib.h"
+#else
 #include "zlib.h"
+#endif
 #endif
 
 

--- a/OsiriXClasses/ROI/ROI.m
+++ b/OsiriXClasses/ROI/ROI.m
@@ -2809,8 +2809,14 @@ static float Sign(NSPoint p1, NSPoint p2, NSPoint p3)
                         c.y = pt.y - p1.y;
 
                         // point in the layer image coordinate system
-                        float y = (c.y-c.x*(v.y/v.x))/(w.y-w.x*(v.y/v.x));
-                        float x = (c.x-y*w.x)/v.x;
+                        float x, y;
+                        if (v.x) {
+                            y = (c.y-c.x*(v.y/v.x))/(w.y-w.x*(v.y/v.x));
+                            x = (c.x-y*w.x)/v.x;
+                        } else {
+                            y = (c.x-c.y*(v.x/v.y))/(w.x-w.y*(v.x/v.y));
+                            x = (c.y-x*w.y)/v.y;
+                        }
                         
                         x *= scaleRatio;
                         y *= scaleRatio;


### PR DESCRIPTION
When tLayer ROIs are rotated by precisely 90 degrees the clickInROI tLayer math fails because of a division by zero.
This pull request adds a test for such condition and provides an alternative.

Regarding NIfTI, I replaced the NIfTI_Library files by getting updates ones (version 2.0.0) from https://sourceforge.net/projects/niftilib/ (official repository referenced by http://nifti.nimh.nih.gov/).
